### PR TITLE
Load configuration from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Database configuration
+DB_HOST=localhost
+DB_NAME=gestortruck
+DB_USER=user
+DB_PASS=secret
+
+# SMTP configuration
+SMTP_HOST=smtp.example.com
+SMTP_USER=username@example.com
+SMTP_PASS=password
+SMTP_PORT=465
+SMTP_SECURE=ssl
+SMTP_FROM_EMAIL=from@example.com
+SMTP_FROM_NAME=Gestor Truck

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Gestor Truck
+
+Esta aplicação utiliza credenciais de banco de dados e SMTP obtidas por variáveis de ambiente. Para configurar o ambiente local:
+
+1. Copie o arquivo `.env.example` para `.env`.
+2. Edite os valores conforme suas credenciais de banco de dados e servidor de e-mail.
+3. Certifique-se de que o PHP possa ler estas variáveis (por exemplo carregando-as com um gerenciador de ambiente ou exportando-as antes de iniciar o servidor).
+
+O arquivo `config.php` fará a leitura dessas variáveis e disponibilizará as configurações para o restante do código.

--- a/config.php
+++ b/config.php
@@ -1,0 +1,30 @@
+<?php
+// Carrega variaveis de ambiente de um arquivo .env, se existir
+$envFile = __DIR__ . '/.env';
+if (file_exists($envFile) && is_readable($envFile)) {
+    foreach (file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        if (str_starts_with(trim($line), '#')) {
+            continue;
+        }
+        if (strpos($line, '=') !== false) {
+            list($name, $value) = array_map('trim', explode('=', $line, 2));
+            putenv("{$name}={$value}");
+        }
+    }
+}
+
+// Configuracoes do banco de dados
+$db_host = getenv('DB_HOST') ?: 'localhost';
+$db_name = getenv('DB_NAME') ?: '';
+$db_user = getenv('DB_USER') ?: '';
+$db_pass = getenv('DB_PASS') ?: '';
+
+// Configuracoes SMTP
+$smtp_host = getenv('SMTP_HOST') ?: 'localhost';
+$smtp_user = getenv('SMTP_USER') ?: '';
+$smtp_pass = getenv('SMTP_PASS') ?: '';
+$smtp_port = getenv('SMTP_PORT') ?: 465;
+$smtp_secure = getenv('SMTP_SECURE') ?: 'ssl';
+$smtp_from_email = getenv('SMTP_FROM_EMAIL') ?: $smtp_user;
+$smtp_from_name = getenv('SMTP_FROM_NAME') ?: 'Gestor Truck';
+?>

--- a/db_config.php
+++ b/db_config.php
@@ -1,14 +1,10 @@
 <?php
-// Configurações do banco de dados
-$host = 'localhost';
-$dbname = 'u856042760_OUfnl';
-$username = 'u856042760_4EtD4';
-$password = 'Le@070210'; // Substituir pela senha correta do banco
+require_once __DIR__ . '/config.php';
 
 try {
-    $pdo = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8", $username, $password);
+    $pdo = new PDO("mysql:host=$db_host;dbname=$db_name;charset=utf8", $db_user, $db_pass);
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
-    die("Erro na conexão com o banco de dados: " . $e->getMessage());
+    die("Erro na conexao com o banco de dados: " . $e->getMessage());
 }
 ?>

--- a/processa_cadastro.php
+++ b/processa_cadastro.php
@@ -4,6 +4,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 session_start();
+require_once 'config.php';
 require_once 'db_config.php';
 require 'PHPMailer/PHPMailer.php';
 require 'PHPMailer/SMTP.php';
@@ -65,14 +66,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             // Enviar e-mail
             $mail = new PHPMailer(true);
             $mail->isSMTP();
-            $mail->Host       = 'smtp.hostinger.com';
+            $mail->Host       = $smtp_host;
             $mail->SMTPAuth   = true;
-            $mail->Username   = 'user_invite@gestortruck.com.br';
-            $mail->Password   = 'Le@070210';
-            $mail->SMTPSecure = 'ssl';
-            $mail->Port       = 465;
+            $mail->Username   = $smtp_user;
+            $mail->Password   = $smtp_pass;
+            $mail->SMTPSecure = $smtp_secure;
+            $mail->Port       = $smtp_port;
 
-            $mail->setFrom('user_invite@gestortruck.com.br', 'Gestor Truck');
+            $mail->setFrom($smtp_from_email, $smtp_from_name);
             $mail->addAddress($email, $nome);
 
             $link = "https://www.gestortruck.com.br/confirmar_email.php?token=" . $token;

--- a/processa_convite.php
+++ b/processa_convite.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'config.php';
 require_once 'db_config.php';
 
 require 'PHPMailer/PHPMailer.php';
@@ -10,8 +11,8 @@ use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
 // Configurações SMTP
-$email_remetente = 'user_invite@gestortruck.com.br';
-$senha_email = 'Le@070210';
+$email_remetente = $smtp_from_email;
+$senha_email = $smtp_pass;
 
 // Dados recebidos
 $account_id = $_SESSION['account_id'];
@@ -161,14 +162,14 @@ try {
     $mail = new PHPMailer(true);
 
     $mail->isSMTP();
-    $mail->Host       = 'smtp.hostinger.com';
+    $mail->Host       = $smtp_host;
     $mail->SMTPAuth   = true;
     $mail->Username   = $email_remetente;
     $mail->Password   = $senha_email;
-    $mail->SMTPSecure = 'ssl';
-    $mail->Port       = 465;
+    $mail->SMTPSecure = $smtp_secure;
+    $mail->Port       = $smtp_port;
 
-    $mail->setFrom($email_remetente, 'Gestor Truck');
+    $mail->setFrom($email_remetente, $smtp_from_name);
     $mail->addAddress($email, $nome);
 
     $mail->isHTML(true);

--- a/reset_senha.php
+++ b/reset_senha.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'config.php';
 require_once 'db_config.php';
 require 'PHPMailer/PHPMailer.php';
 require 'PHPMailer/SMTP.php';
@@ -33,14 +34,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $mail = new PHPMailer(true);
 
             $mail->isSMTP();
-            $mail->Host       = 'smtp.hostinger.com';
+            $mail->Host       = $smtp_host;
             $mail->SMTPAuth   = true;
-            $mail->Username   = 'user_invite@gestortruck.com.br';
-            $mail->Password   = 'Le@070210';
-            $mail->SMTPSecure = 'ssl';
-            $mail->Port       = 465;
+            $mail->Username   = $smtp_user;
+            $mail->Password   = $smtp_pass;
+            $mail->SMTPSecure = $smtp_secure;
+            $mail->Port       = $smtp_port;
 
-            $mail->setFrom('user_invite@gestortruck.com.br', 'Gestor Truck');
+            $mail->setFrom($smtp_from_email, $smtp_from_name);
             $mail->addAddress($email, $usuario['nome']);
 
             $link = "https://www.gestortruck.com.br/definir_nova_senha.php?token=" . $token;

--- a/teste_smtp.php
+++ b/teste_smtp.php
@@ -2,6 +2,8 @@
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
+require_once 'config.php';
+
 require 'PHPMailer/PHPMailer.php';
 require 'PHPMailer/SMTP.php';
 require 'PHPMailer/Exception.php';
@@ -10,17 +12,17 @@ $mail = new PHPMailer(true);
 
 try {
     $mail->isSMTP();
-    $mail->Host       = 'smtp.hostinger.com';
+    $mail->Host       = $smtp_host;
     $mail->SMTPAuth   = true;
-    $mail->Username   = 'user_invite@gestortruck.com.br';
-    $mail->Password   = 'Le@070210';
-    $mail->SMTPSecure = 'ssl'; // ou 'tls' para porta 587
-    $mail->Port       = 465; // ou 587 se usar tls
+    $mail->Username   = $smtp_user;
+    $mail->Password   = $smtp_pass;
+    $mail->SMTPSecure = $smtp_secure; // ou 'tls' para porta 587
+    $mail->Port       = $smtp_port; // ou 587 se usar tls
 
     // Remetente
-    $mail->setFrom('user_invite@gestortruck.com.br', 'Gestor Truck Teste');
+    $mail->setFrom($smtp_from_email, 'Gestor Truck Teste');
     // Destinatário
-    $mail->addAddress('user_invite@gestortruck.com.br', 'Gestor Truck');
+    $mail->addAddress($smtp_from_email, 'Gestor Truck');
 
     // Conteúdo
     $mail->isHTML(true);


### PR DESCRIPTION
## Summary
- add `config.php` to read DB and SMTP settings from environment
- update DB connection and mailer scripts to consume the new config
- document environment variables and add `.env.example`

## Testing
- `php -l config.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca500acc08328b1e82ad2a0d9a8e8