### PR TITLE
Add SMTP test instructions and ignore local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Environment files
+.env
+
+# Local testing script
+teste_smtp.php
+
+# Temporary files
+*.log
+*.tmp
+*.cache
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@ Esta aplicação utiliza credenciais de banco de dados e SMTP obtidas por variá
 3. Certifique-se de que o PHP possa ler estas variáveis (por exemplo carregando-as com um gerenciador de ambiente ou exportando-as antes de iniciar o servidor).
 
 O arquivo `config.php` fará a leitura dessas variáveis e disponibilizará as configurações para o restante do código.
+
+## Testar envio SMTP localmente
+
+Um script de exemplo está disponível em `examples/teste_smtp.php` para verificar se as configurações de e-mail estão corretas.
+
+1. Preencha as variáveis relacionadas ao SMTP no arquivo `.env`.
+2. A partir da raiz do projeto, execute:
+
+```bash
+php examples/teste_smtp.php
+```
+
+Se tudo estiver configurado corretamente, será exibida uma mensagem indicando que o e-mail foi enviado.

--- a/examples/teste_smtp.php
+++ b/examples/teste_smtp.php
@@ -2,11 +2,11 @@
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
-require_once 'config.php';
+require_once __DIR__ . '/../config.php';
 
-require 'PHPMailer/PHPMailer.php';
-require 'PHPMailer/SMTP.php';
-require 'PHPMailer/Exception.php';
+require __DIR__ . '/../PHPMailer/PHPMailer.php';
+require __DIR__ . '/../PHPMailer/SMTP.php';
+require __DIR__ . '/../PHPMailer/Exception.php';
 
 $mail = new PHPMailer(true);
 


### PR DESCRIPTION
## Summary
- ignore runtime files like `.env` and local SMTP tester
- move SMTP test helper to `examples/`
- document how to run SMTP tests

## Testing
- `php -l examples/teste_smtp.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbb79e6148328a0daa0bbb2522a74