### PR TITLE
Update motoristas to manual registration

### DIFF
--- a/processa_motorista.php
+++ b/processa_motorista.php
@@ -1,0 +1,48 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$account_id = $_SESSION['account_id'];
+
+$acao = $_POST['acao'] ?? 'salvar';
+$id_motorista = $_POST['id_motorista'] ?? null;
+$nome = $_POST['nome'] ?? '';
+$status = $_POST['status'] ?? 'ativo';
+
+try {
+    if ($acao === 'remover') {
+        if (!$id_motorista) die('ID n\xc3\xa3o informado.');
+        $stmt = $pdo->prepare("DELETE FROM motoristas WHERE id = :id AND account_id = :account_id");
+        $stmt->execute(['id' => $id_motorista, 'account_id' => $account_id]);
+        header('Location: motoristas.php');
+        exit;
+    }
+
+    if ($id_motorista) {
+        $stmt = $pdo->prepare("UPDATE motoristas SET nome = :nome, status = :status WHERE id = :id AND account_id = :account_id");
+        $stmt->execute([
+            'nome' => $nome,
+            'status' => $status,
+            'id' => $id_motorista,
+            'account_id' => $account_id
+        ]);
+    } else {
+        $stmt = $pdo->prepare("INSERT INTO motoristas (account_id, nome, status) VALUES (:account_id, :nome, :status)");
+        $stmt->execute([
+            'account_id' => $account_id,
+            'nome' => $nome,
+            'status' => $status
+        ]);
+    }
+
+    header('Location: motoristas.php?status=sucesso');
+    exit;
+} catch (Exception $e) {
+    die('Erro: ' . $e->getMessage());
+}
+?>


### PR DESCRIPTION
## Summary
- query motoristas table instead of convites
- add processa_motorista.php for CRUD operations
- replace invitation drawer with manual form
- add removal modal and javascript helpers

## Testing
- `php -l` **failed: php command not found**

------
https://chatgpt.com/codex/tasks/task_e_685dcb16825883288377e7ac70eb8946