### PR TITLE
Cadastro manual de motoristas

### DIFF
--- a/motoristas.php
+++ b/motoristas.php
@@ -28,24 +28,18 @@ $motoristas = $stmt->fetchAll(PDO::FETCH_ASSOC);
   <title>Gestão de Motoristas - Gestor Truck</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/@phosphor-icons/web"></script>
+  <style>
+    .required-label::after { content: ' *'; color: red; }
+  </style>
 </head>
 <body class="bg-gray-100">
 <div class="flex">
   <?php include 'menu_sidebar.php'; ?>
 
   <div class="flex-1 p-6">
-    <?php if (isset($_GET['link'])): ?>
+    <?php if (isset($_GET['sucesso'])): ?>
       <div class="bg-green-100 text-green-700 px-4 py-3 rounded mb-4 text-center">
-        <p class="font-semibold mb-2">✔️ Link gerado com sucesso!</p>
-        <?php
-          $url = 'https://gestortruck.com.br/cadastro_usuario.php?token=' . urlencode($_GET['link']);
-          $mailLink = 'mailto:?subject=Convite%20Gestor%20Truck&body=' . urlencode('Cadastre-se pelo link: ' . $url);
-          $waLink = 'https://wa.me/?text=' . urlencode('Cadastre-se no Gestor Truck: ' . $url);
-        ?>
-        <div class="flex justify-center gap-4">
-          <a href="<?= $mailLink ?>" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded" target="_blank">Enviar por Email</a>
-          <a href="<?= $waLink ?>" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded" target="_blank">Enviar pelo WhatsApp</a>
-        </div>
+        <p class="font-semibold">✔️ Motorista cadastrado com sucesso!</p>
       </div>
     <?php endif; ?>
     <div class="flex justify-between items-center mb-6">
@@ -85,22 +79,127 @@ $motoristas = $stmt->fetchAll(PDO::FETCH_ASSOC);
 </div>
 
 <!-- Drawer -->
-<div id="drawer" class="fixed top-0 right-0 w-96 h-full bg-white shadow-lg transform translate-x-full transition-transform duration-300 z-50">
+<div id="drawer" class="fixed top-0 right-0 w-1/2 h-full bg-white shadow-lg transform translate-x-full transition-transform duration-300 z-50">
   <div class="flex justify-between items-center p-4 border-b">
     <h2 class="text-xl font-bold" id="drawerTitle">Novo Motorista</h2>
     <button onclick="closeDrawer()"><i class="ph ph-x text-xl"></i></button>
   </div>
   <div class="p-4">
-    <form id="formMotorista" action="processa_motorista.php" method="POST" class="space-y-4">
+    <form id="formMotorista" action="processa_motorista.php" method="POST" class="space-y-4 overflow-y-auto h-[90vh] pr-2">
       <div>
-        <label class="block text-sm font-medium">Nome do Motorista</label>
-        <input type="text" name="nome" id="nome" required class="w-full border rounded-md px-3 py-2">
+        <label class="block text-sm font-medium required-label">Nome</label>
+        <input type="text" name="nome" id="nome" class="w-full border rounded-md px-3 py-2">
+        <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium required-label">CPF</label>
+          <input type="text" name="cpf" id="cpf" maxlength="14" oninput="mascaraCPF(this)" class="w-full border rounded-md px-3 py-2">
+          <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+        <div>
+          <label class="block text-sm font-medium">RG</label>
+          <input type="text" name="rg" id="rg" class="w-full border rounded-md px-3 py-2">
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium required-label">Data de Nascimento</label>
+          <input type="date" name="data_nascimento" id="data_nascimento" class="w-full border rounded-md px-3 py-2">
+        <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+        <div>
+          <label class="block text-sm font-medium required-label">Telefone</label>
+          <input type="text" name="telefone" id="telefone" maxlength="15" oninput="mascaraTelefone(this)" class="w-full border rounded-md px-3 py-2">
+        <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div class="col-span-2">
+          <label class="block text-sm font-medium">Email</label>
+          <input type="email" name="email" id="email" class="w-full border rounded-md px-3 py-2">
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium required-label">CNH</label>
+          <input type="text" name="cnh" id="cnh" class="w-full border rounded-md px-3 py-2">
+        <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+        <div>
+          <label class="block text-sm font-medium required-label">Categoria CNH</label>
+          <input type="text" name="categoria_cnh" id="categoria_cnh" class="w-full border rounded-md px-3 py-2">
+        <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium required-label">Validade CNH</label>
+          <input type="date" name="validade_cnh" id="validade_cnh" class="w-full border rounded-md px-3 py-2">
+        <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+        <div>
+          <label class="block text-sm font-medium required-label">Data de Admissão</label>
+          <input type="date" name="data_admissao" id="data_admissao" class="w-full border rounded-md px-3 py-2">
+        <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium required-label">CEP</label>
+          <input type="text" name="cep" id="cep" class="w-full border rounded-md px-3 py-2">
+          <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+        <div>
+          <label class="block text-sm font-medium required-label">Endereço</label>
+          <input type="text" name="endereco" id="endereco" class="w-full border rounded-md px-3 py-2">
+          <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium required-label">Bairro</label>
+          <input type="text" name="bairro" id="bairro" class="w-full border rounded-md px-3 py-2">
+          <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+        <div>
+          <label class="block text-sm font-medium required-label">Cidade</label>
+          <input type="text" name="cidade" id="cidade" class="w-full border rounded-md px-3 py-2">
+          <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium required-label">Estado</label>
+          <input type="text" name="estado" id="estado" class="w-full border rounded-md px-3 py-2">
+          <span class="text-red-500 text-sm hidden">Campo obrigatório</span>
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium">Banco</label>
+          <input type="text" name="banco" id="banco" class="w-full border rounded-md px-3 py-2">
+        </div>
+        <div>
+          <label class="block text-sm font-medium">Agência</label>
+          <input type="text" name="agencia" id="agencia" class="w-full border rounded-md px-3 py-2">
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <div>
+          <label class="block text-sm font-medium">Conta</label>
+          <input type="text" name="conta" id="conta" class="w-full border rounded-md px-3 py-2">
+        </div>
+        <div>
+          <label class="block text-sm font-medium">PIX</label>
+          <input type="text" name="pix" id="pix" class="w-full border rounded-md px-3 py-2">
+        </div>
       </div>
       <div>
-        <label class="block text-sm font-medium">Telefone</label>
-        <input type="text" name="telefone" id="telefone" required class="w-full border rounded-md px-3 py-2">
+        <label class="block text-sm font-medium">Observações</label>
+        <textarea name="observacoes" id="observacoes" class="w-full border rounded-md px-3 py-2"></textarea>
       </div>
-      <button type="submit" id="btnGerar" disabled class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-md w-full">Gerar Link</button>
+      <button type="submit" id="btnSalvar" disabled class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-md w-full">Salvar</button>
     </form>
   </div>
 </div>
@@ -126,6 +225,18 @@ $motoristas = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </button>
       </div>
     </form>
+</div>
+</div>
+
+<!-- Modal Confirmação -->
+<div id="modalConfirm" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
+  <div class="bg-white rounded-lg shadow-lg w-full max-w-sm p-6">
+    <h2 class="text-xl font-semibold mb-4">Confirmar Cadastro</h2>
+    <p class="mb-6">Deseja realmente salvar o motorista?</p>
+    <div class="flex justify-end gap-4">
+      <button type="button" onclick="fecharModalConfirm()" class="px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded">Cancelar</button>
+      <button type="button" onclick="enviarFormulario()" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded">Confirmar</button>
+    </div>
   </div>
 </div>
 
@@ -133,7 +244,8 @@ $motoristas = $stmt->fetchAll(PDO::FETCH_ASSOC);
   function openDrawer() {
     document.getElementById('drawerTitle').innerText = 'Novo Motorista';
     document.getElementById('formMotorista').reset();
-    document.getElementById('btnGerar').disabled = true;
+    document.getElementById('btnSalvar').disabled = true;
+    document.querySelectorAll('#formMotorista span.text-red-500').forEach(s => s.classList.add('hidden'));
     document.getElementById('drawer').classList.remove('translate-x-full');
     document.getElementById('drawer-backdrop').classList.remove('hidden');
   }
@@ -141,13 +253,80 @@ $motoristas = $stmt->fetchAll(PDO::FETCH_ASSOC);
     document.getElementById('drawer').classList.add('translate-x-full');
     document.getElementById('drawer-backdrop').classList.add('hidden');
   }
-  document.getElementById('nome').addEventListener('input', verificarCampos);
-  document.getElementById('telefone').addEventListener('input', verificarCampos);
+  const requiredIds = ['nome','cpf','data_nascimento','telefone','cnh','categoria_cnh','validade_cnh','data_admissao','cep','endereco','bairro','cidade','estado'];
+  requiredIds.forEach(id => {
+    document.getElementById(id).addEventListener('input', verificarCampos);
+  });
 
   function verificarCampos() {
-    const nome = document.getElementById('nome').value.trim();
-    const telefone = document.getElementById('telefone').value.trim();
-    document.getElementById('btnGerar').disabled = !(nome && telefone);
+    let preenchido = true;
+    requiredIds.forEach(id => {
+      const val = document.getElementById(id).value.trim();
+      if (!val) preenchido = false;
+    });
+    document.getElementById('btnSalvar').disabled = !preenchido;
+  }
+
+  document.getElementById('formMotorista').addEventListener('submit', function(e) {
+    e.preventDefault();
+    let valid = true;
+    requiredIds.forEach(id => {
+      const input = document.getElementById(id);
+      const error = input.nextElementSibling;
+      if (input.value.trim() === '') {
+        error.classList.remove('hidden');
+        valid = false;
+      } else {
+        error.classList.add('hidden');
+      }
+    });
+    if (valid) {
+      document.getElementById('modalConfirm').classList.remove('hidden');
+    }
+  });
+
+  function fecharModalConfirm() {
+    document.getElementById('modalConfirm').classList.add('hidden');
+  }
+
+  function enviarFormulario() {
+    document.getElementById('modalConfirm').classList.add('hidden');
+    document.getElementById('formMotorista').submit();
+  }
+
+  document.getElementById('cep').addEventListener('blur', buscarEndereco);
+
+  function mascaraCPF(el) {
+    let v = el.value.replace(/\D/g, '');
+    v = v.replace(/(\d{3})(\d)/, '$1.$2');
+    v = v.replace(/(\d{3})(\d)/, '$1.$2');
+    v = v.replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+    el.value = v;
+  }
+
+  function mascaraTelefone(el) {
+    let v = el.value.replace(/\D/g, '');
+    v = v.replace(/^(\d{2})(\d)/g, '($1) $2');
+    v = v.replace(/(\d{4,5})(\d{4})$/, '$1-$2');
+    el.value = v;
+  }
+
+  function buscarEndereco() {
+    const cep = document.getElementById('cep').value.replace(/\D/g, '');
+    if (cep.length === 8) {
+      fetch(`https://viacep.com.br/ws/${cep}/json/`)
+        .then(r => r.json())
+        .then(d => {
+          if (!('erro' in d)) {
+            document.getElementById('endereco').value = d.logradouro;
+            document.getElementById('bairro').value = d.bairro;
+            document.getElementById('cidade').value = d.localidade;
+            document.getElementById('estado').value = d.uf;
+            verificarCampos();
+          }
+        })
+        .catch(() => {});
+    }
   }
 </script>
 </body>

--- a/processa_motorista.php
+++ b/processa_motorista.php
@@ -8,28 +8,92 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $account_id = $_SESSION['account_id'];
-$nome = $_POST['nome'] ?? '';
-$telefone = $_POST['telefone'] ?? '';
 
-if (!$nome || !$telefone) {
+// Coletar dados
+$nome = $_POST['nome'] ?? '';
+$cpf = $_POST['cpf'] ?? '';
+$rg = $_POST['rg'] ?? null;
+$data_nascimento = $_POST['data_nascimento'] ?? '';
+$telefone = $_POST['telefone'] ?? '';
+$email = $_POST['email'] ?? null;
+$cnh = $_POST['cnh'] ?? '';
+$categoria_cnh = $_POST['categoria_cnh'] ?? '';
+$validade_cnh = $_POST['validade_cnh'] ?? '';
+$data_admissao = $_POST['data_admissao'] ?? '';
+$endereco = $_POST['endereco'] ?? '';
+$bairro = $_POST['bairro'] ?? '';
+$cidade = $_POST['cidade'] ?? '';
+$estado = $_POST['estado'] ?? '';
+$cep = $_POST['cep'] ?? '';
+$banco = $_POST['banco'] ?? null;
+$agencia = $_POST['agencia'] ?? null;
+$conta = $_POST['conta'] ?? null;
+$pix = $_POST['pix'] ?? null;
+$observacoes = $_POST['observacoes'] ?? null;
+
+if (!$nome || !$cpf || !$cnh || !$telefone) {
     header('Location: motoristas.php');
     exit;
 }
 
-$token = bin2hex(random_bytes(16));
+$senhaGerada = bin2hex(random_bytes(4));
+$senhaHash = password_hash($senhaGerada, PASSWORD_DEFAULT);
 
 try {
-    $stmt = $pdo->prepare("INSERT INTO convites_usuarios (account_id, nome, telefone, tipo_usuario, token, status) VALUES (:account_id, :nome, :telefone, 'Motorista', :token, 'pendente')");
+    // verificar coluna user_id na tabela motoristas
+    $check = $pdo->query("SHOW COLUMNS FROM motoristas LIKE 'user_id'");
+    if ($check->rowCount() == 0) {
+        $pdo->exec("ALTER TABLE motoristas ADD COLUMN user_id INT NULL");
+    }
+
+    $pdo->beginTransaction();
+
+    // criar usuario
+    $stmt = $pdo->prepare("INSERT INTO users (account_id, nome, email, senha) VALUES (:account_id, :nome, :email, :senha)");
     $stmt->execute([
         'account_id' => $account_id,
-        'nome'       => $nome,
-        'telefone'   => $telefone,
-        'token'      => $token
+        'nome' => $nome,
+        'email' => $email,
+        'senha' => $senhaHash
+    ]);
+    $user_id = $pdo->lastInsertId();
+
+    // permissões padrão zeradas
+    $stmt = $pdo->prepare("INSERT INTO permissoes_usuarios (user_id, pode_gerenciar_viagens, pode_gerenciar_abastecimentos, pode_gerenciar_manutencoes, pode_gerenciar_clientes, pode_gerenciar_usuarios, pode_ver_relatorios) VALUES (:user_id,0,0,0,0,0,0)");
+    $stmt->execute(['user_id' => $user_id]);
+
+    // inserir motorista
+    $stmt = $pdo->prepare("INSERT INTO motoristas (account_id, user_id, nome, cpf, rg, data_nascimento, cnh, categoria_cnh, validade_cnh, telefone, email, endereco, bairro, cidade, estado, cep, banco, agencia, conta, pix, status, observacoes, data_admissao) VALUES (:account_id, :user_id, :nome, :cpf, :rg, :data_nascimento, :cnh, :categoria_cnh, :validade_cnh, :telefone, :email, :endereco, :bairro, :cidade, :estado, :cep, :banco, :agencia, :conta, :pix, 'ativo', :observacoes, :data_admissao)");
+    $stmt->execute([
+        'account_id' => $account_id,
+        'user_id' => $user_id,
+        'nome' => $nome,
+        'cpf' => $cpf,
+        'rg' => $rg,
+        'data_nascimento' => $data_nascimento,
+        'cnh' => $cnh,
+        'categoria_cnh' => $categoria_cnh,
+        'validade_cnh' => $validade_cnh,
+        'telefone' => $telefone,
+        'email' => $email,
+        'endereco' => $endereco,
+        'bairro' => $bairro,
+        'cidade' => $cidade,
+        'estado' => $estado,
+        'cep' => $cep,
+        'banco' => $banco,
+        'agencia' => $agencia,
+        'conta' => $conta,
+        'pix' => $pix,
+        'observacoes' => $observacoes,
+        'data_admissao' => $data_admissao
     ]);
 
-    header('Location: motoristas.php?link=' . $token);
+    $pdo->commit();
+
+    header('Location: motoristas.php?sucesso=1');
     exit;
 } catch (Exception $e) {
+    $pdo->rollBack();
     die('Erro: ' . $e->getMessage());
 }
-?>


### PR DESCRIPTION
## Summary
- expand driver drawer width
- highlight required fields and validate on save
- confirm before submitting new driver
- reordenar CEP para antes de endereço e preencher dados via ViaCEP
- ajusta cadastro de motorista para tornar email opcional e remover senha/telefone de emergência
- aplica máscaras de CPF e telefone
- adicionar modal de confirmação customizado
- corrigir inserção criando coluna `user_id` quando necessário
- remover validação nativa do navegador

## Testing
- ❌ `php -l motoristas.php` (command not found)
- ❌ `php -l processa_motorista.php` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_6863dbd5fe288328986f730cec2429ad